### PR TITLE
1.10 Non-ladder runewords

### DIFF
--- a/RuneWordFinder4/seeds/runewords/runewords.json
+++ b/RuneWordFinder4/seeds/runewords/runewords.json
@@ -70,7 +70,7 @@
     "name": "Honor",
     "version": "original",
     "type": "Melee Weapons",
-    "runes": [ "Amn", "El", "Ith", "Tir", "Sol" ],
+    "runes": [ "amn", "el", "ith", "tir", "sol" ],
     "stats": [
       "+160% Enhanced Damage",
       "+9 To Minimum Damage",
@@ -89,7 +89,7 @@
     "name": "King's Grace",
     "version": "original",
     "type": "Swords/Scepters",
-    "runes": [ "Amn", "Ral", "Thul" ],
+    "runes": [ "amn", "ral", "thul" ],
     "stats": [
       "+100% Enhanced Damage",
       "+100% Damage To Demons",
@@ -204,7 +204,7 @@
     "name": "Nadir",
     "version": "original",
     "type": "Staves",
-    "runes": [ "lum", "io", "sol", "eth" ],
+    "runes": [ "nef", "tir" ],
     "stats": [
       "+50% Enhanced Defense",
       "+10 Defense",

--- a/RuneWordFinder4/seeds/runewords/runewords.json
+++ b/RuneWordFinder4/seeds/runewords/runewords.json
@@ -3,9 +3,7 @@
     "name": "Ancient's Pledge",
     "version": "original",
     "type": "Shield",
-    "runeName": "RalOrtTal",
     "runes": [ "ral", "ort", "tal" ],
-    "sockets": 3,
     "stats": [
       "+50 Enhanced Defense",
       "Cold Resist +43%",
@@ -19,9 +17,7 @@
     "name": "Black",
     "version": "original",
     "type":  "Clubs/Hammers/Maces",
-    "runeName": "ThulIoNef",
     "runes": [ "thul", "io", "nef" ],
-    "sockets": 3,
     "stats": [
       "+120% Enhanced Damage",
       "40% Chance Of Crushing Blow",
@@ -38,9 +34,7 @@
     "name": "Fury",
     "version": "original",
     "type": "Melee Weapon",
-    "runeName": "JahGulEth",
     "runes": [ "jah", "gul", "eth" ],
-    "sockets": 3,
     "stats": [
       "+209% Enhanced Damage",
       "40% Increased Attack Speed",
@@ -58,9 +52,7 @@
     "name": "Holy Thunder",
     "version": "original",
     "type": "Scepters",
-    "runeName": "EthRalOrtTal",
     "runes": [ "eth", "ral", "ort", "tal" ],
-    "sockets": 4,
     "stats": [
       "+60% Enhanced Damage",
       "-25% Target Defense",
@@ -78,9 +70,7 @@
     "name": "Honor",
     "version": "original",
     "type": "Melee Weapons",
-    "runeName": "AmnElIthTirSol",
     "runes": [ "Amn", "El", "Ith", "Tir", "Sol" ],
-    "sockets": 5,
     "stats": [
       "+160% Enhanced Damage",
       "+9 To Minimum Damage",
@@ -99,9 +89,7 @@
     "name": "King's Grace",
     "version": "original",
     "type": "Swords/Scepters",
-    "runeName": "AmnRalThul",
     "runes": [ "Amn", "Ral", "Thul" ],
-    "sockets": 3,
     "stats": [
       "+100% Enhanced Damage",
       "+100% Damage To Demons",
@@ -118,9 +106,7 @@
     "name": "Leaf",
     "version": "original",
     "type": "Staves",
-    "runeName": "TirRal",
     "runes": [ "tir", "ral" ],
-    "sockets": 2,
     "stats": [
       "Adds 5-30 Fire Damage",
       "+3 To Fire Skills",
@@ -136,9 +122,7 @@
     "name": "Lionheart",
     "version": "original",
     "type": "Armor",
-    "runeName": "HelLumFal",
     "runes": [ "hel", "lum", "fal" ],
-    "sockets": 3,
     "stats": [
       "+20% Enhanced Damage",
       "Requirements -15%",
@@ -154,9 +138,7 @@
     "name": "Lore",
     "version": "original",
     "type": "Helm",
-    "runeName": "OrtSol",
     "runes": [ "ort", "sol" ],
-    "sockets": 2,
     "stats": [
       "+1 To All Skill Levels",
       "+10 To Energy",
@@ -170,9 +152,7 @@
     "name": "Malice",
     "version": "original",
     "type": "Melee Weapons",
-    "runeName": "IthElEth",
     "runes": [ "ith", "el", "eth" ],
-    "sockets": 3,
     "stats": [
       "+33% Enhanced Damage",
       "+9 To Maximum Damage",
@@ -188,9 +168,7 @@
     "name": "Melody",
     "version": "original",
     "type": "Missile Weapons",
-    "runeName": "ShaelKoNef",
     "runes": [ "shael", "ko", "nef" ],
-    "sockets": 3,
     "stats": [
       "+50% Enhanced Damage",
       "+300% Damage To Undead",
@@ -207,9 +185,7 @@
     "name": "Memory",
     "version": "original",
     "type": "Staves",
-    "runeName": "LumIoSolEth",
     "runes": [ "lum", "io", "sol", "eth" ],
-    "sockets": 4,
     "stats": [
       "+3 to Sorceress Skill Levels",
       "33% Faster Cast Rate",
@@ -228,9 +204,7 @@
     "name": "Nadir",
     "version": "original",
     "type": "Staves",
-    "runeName": "LumIoSolEth",
     "runes": [ "lum", "io", "sol", "eth" ],
-    "sockets": 4,
     "stats": [
       "+50% Enhanced Defense",
       "+10 Defense",
@@ -246,9 +220,7 @@
     "name": "Radiance",
     "version": "original",
     "type": "Helm",
-    "runeName": "NefSolIth",
     "runes": [ "nef", "sol", "ith" ],
-    "sockets": 3,
     "stats": [
       "+75% Enhanced Defense",
       "+30 Defense Vs. Missile",
@@ -265,9 +237,7 @@
     "name": "Rhyme",
     "version": "original",
     "type": "Shield",
-    "runeName": "ShaelEth",
     "runes": [ "shael", "eth" ],
-    "sockets": 2,
     "stats": [
       "20% Increased Chance of Blocking",
       "40% Faster Block Rate",
@@ -282,9 +252,7 @@
     "name": "Silence",
     "version": "original",
     "type": "Weapon",
-    "runeName": "SolEldHelIstTirVex",
     "runes": [ "dol", "eld", "hel", "ist", "tir", "vex" ],
-    "sockets": 6,
     "stats": [
       "200% Enhanced Damage",
       "+75% Damage To Undead",
@@ -305,9 +273,7 @@
     "name": "Smoke",
     "version": "original",
     "type": "Armor",
-    "runeName": "NefLum",
     "runes": [ "nef", "lum" ],
-    "sockets": 2,
     "stats": [
       "+75% Enhanced Defense",
       "+280 Defense Vs. Missile",
@@ -322,9 +288,7 @@
     "name": "Stealth",
     "version": "original",
     "type": "Armor",
-    "runeName": "TalEth",
     "runes": [ "tal", "eth" ],
-    "sockets": 2,
     "stats": [
       "Magic Damage Reduced By 3",
       "+6 To Dexterity",
@@ -340,9 +304,7 @@
     "name": "Steel",
     "version": "original",
     "type": "Swords/Axes/Maces",
-    "runeName": "TirEl",
     "runes": [ "tir", "el" ],
-    "sockets": 2,
     "stats": [
       "20% Enhanced Damage",
       "+3 To Minimum Damage",
@@ -358,9 +320,7 @@
     "name": "Strength",
     "version": "original",
     "type": "Melee Weapons",
-    "runeName": "AmnTir",
     "runes": [ "amn", "tir" ],
-    "sockets": 2,
     "stats": [
       "35% Enhanced Damage",
       "25% Chance Of Crushing Blow",
@@ -374,9 +334,7 @@
     "name": "Venom",
     "version": "original",
     "type": "Weapons",
-    "runeName": "TalDolMal",
     "runes": [ "tal", "dol", "mal" ],
-    "sockets": 3,
     "stats": [
       "Hit Causes Monster To Flee 25%",
       "Prevent Monster Heal",
@@ -391,9 +349,7 @@
     "name": "Wealth",
     "version": "original",
     "type": "Armor",
-    "runeName": "LemKoTir",
     "runes": [ "lem", "ko", "tir" ],
-    "sockets": 3,
     "stats": [
       "300% Extra Gold From Monsters",
       "100% Better Chance Of Getting Magic Items",
@@ -405,9 +361,7 @@
     "name": "White",
     "version": "original",
     "type": "Wand",
-    "runeName": "DolIo",
     "runes": [ "dol", "io" ],
-    "sockets": 2,
     "stats": [
       "Hit Causes Monster To Flee 25%",
       "+10 To Vitality",
@@ -424,9 +378,7 @@
     "name": "Zephyr",
     "version": "original",
     "type": "Missile Weapons",
-    "runeName": "OrtEth",
     "runes": [ "ort", "eth" ],
-    "sockets": 2,
     "stats": [
       "+33% Enhanced Damage",
       "+66 To Attack Rating",
@@ -436,6 +388,459 @@
       "25% Faster Run/Walk",
       "25% Increased Attack Speed",
       "7% Chance To Cast Level 1 Twister When Struck"
+    ]
+  },
+  {
+    "name": "Beast",
+    "version": "1.10",
+    "type": "Axes/Scepters/Hammers",
+    "runes": [ "ber", "tir", "um", "mal", "lum" ],
+    "stats": [
+      "Level 9 Fanaticism Aura When Equipped",
+      "+40% Increased Attack Speed",
+      "+240-270% Enhanced Damage (varies)",
+      "20% Chance of Crushing Blow",
+      "25% Chance of Open Wounds",
+      "+3 To Werebear",
+      "+3 To Lycanthropy",
+      "Prevent Monster Heal",
+      "+25-40 To Strength (varies)",
+      "+10 To Energy",
+      "+2 To Mana After Each Kill",
+      "Level 13 Summon Grizzly (5 Charges)"
+    ]
+  },
+  {
+    "name": "Bramble",
+    "version": "1.10",
+    "type": "Armor",
+    "runes": [ "ral", "ohm", "sur", "eth" ],
+    "stats": [
+        "Level 15-21 Thorns Aura When Equipped (varies)",
+        "+50% Faster Hit Recovery",
+        "+25-50% To Poison Skill Damage (varies)",
+        "+300 Defense",
+        "Increase Maximum Mana 5%",
+        "Regenerate Mana 15%",
+        "+5% To Maximum Cold Resist",
+        "Fire Resist +30%",
+        "Poison Resist +100%",
+        "+13 Life After Each Kill",
+        "Level 13 Spirit of Barbs (33 Charges)"
+    ]
+  },
+  {
+    "name": "Breath of the Dying",
+    "version": "1.10",
+    "type": "Weapons",
+    "runes": [ "vex", "hel", "el", "eld", "zod", "eth" ],
+    "stats": [
+        "50% Chance To Cast Level 20 Poison Nova When You Kill An Enemy",
+        "Indestructible",
+        "+60% Increased Attack Speed",
+        "+350-400% Enhanced Damage (varies)",
+        "+200% Damage To Undead",
+        "-25% Target Defense",
+        "+50 To Attack Rating",
+        "+50 To Attack Rating Against Undead",
+        "7% Mana Stolen Per Hit",
+        "12-15% Life Stolen Per Hit (varies)",
+        "Prevent Monster Heal",
+        "+30 To All Attributes",
+        "+1 To Light Radius",
+        "Requirements -20%"
+    ]
+  },
+  {
+    "name": "Call to Arms",
+    "version": "1.10",
+    "type": "",
+    "runes": [ "amn", "ral", "mal", "ist", "ohm" ],
+    "stats": [
+        "+1 To All Skills",
+        "+40% Increased Attack Speed",
+        "+250-290% Enhanced Damage (varies)",
+        "Adds 5-30 Fire Damage",
+        "7% Life Stolen Per Hit",
+        "+2-6 To Battle Command (varies)*",
+        "+1-6 To Battle Orders (varies)*",
+        "+1-4 To Battle Cry (varies)*",
+        "Prevent Monster Heal",
+        "Replenish Life +12",
+        "30% Better Chance of Getting Magic Items",
+        "*Barbarians cap at +3 due to 'oskills' cap"
+    ]
+  },
+  {
+    "name": "Chains of Honor",
+    "version": "1.10",
+    "type": "Armor",
+    "runes": [ "dol", "um", "ber", "ist" ],
+    "stats": [
+        "+2 To All Skills",
+        "+200% Damage To Demons",
+        "+100% Damage To Undead",
+        "8% Life Stolen Per Hit",
+        "+70% Enhanced Defense",
+        "+20 To Strength",
+        "Replenish Life +7",
+        "All Resistances +65",
+        "Damage Reduced By 8%",
+        "25% Better Chance of Getting Magic Items"
+    ]
+  },
+  {
+    "name": "Chaos",
+    "version": "1.10",
+    "type": "Claws",
+    "runes": [ "fal", "ohm", "uhm" ],
+    "stats": [
+        "9% Chance To Cast Level 11 Frozen Orb On Striking",
+        "11% Chance To Cast Level 9 Charged Bolt On Striking",
+        "+35% Increased Attack Speed",
+        "+290-340% Enhanced Damage (varies)",
+        "Adds 216-471 Magic Damage",
+        "25% Chance of Open Wounds",
+        "+1 To Whirlwind",
+        "+10 To Strength",
+        "+15 Life After Each Demon Kill"
+    ]
+  },
+  {
+    "name": "Crescent Moon",
+    "version": "1.10",
+    "type": "Axes/Swords/Polearms",
+    "runes": [ "shael", "um", "tir" ],
+    "stats": [
+        "10% Chance To Cast Level 17 Chain Lightning On Striking",
+        "7% Chance To Cast Level 13 Static Field On Striking",
+        "+20% Increased Attack Speed",
+        "+180-220% Enhanced Damage (varies)",
+        "Ignore Target's Defense",
+        "-35% To Enemy Lightning Resistance",
+        "25% Chance of Open Wounds",
+        "+9-11 Magic Absorb (varies)",
+        "+2 To Mana After Each Kill",
+        "Level 18 Summon Spirit Wolf (30 Charges)"
+    ]
+  },
+  {
+    "name": "Delirium",
+    "version": "1.10",
+    "type": "Helms",
+    "runes": [ "lem", "ist", "io" ],
+    "stats": [
+        "1% Chance To Cast Level 50 Delirium* (morph) When Struck",
+        "6% Chance To Cast Level 14 Mind Blast When Struck",
+        "14% Chance To Cast Level 13 Terror When Struck",
+        "11% Chance To Cast Level 18 Confuse On Striking",
+        "+2 To All Skills",
+        "+261 Defense",
+        "+10 To Vitality",
+        "50% Extra Gold From Monsters",
+        "25% Better Chance of Getting Magic Items",
+        "Level 17 Attract (60 Charges)",
+        "*Delirium morphs the character into a Bone Fetish for ~1 minute. You can still perform normal attacks"
+    ]
+  },
+  {
+    "name": "Doom",
+    "version": "1.10",
+    "type": "Axes/Polearms/Hammers",
+    "runes": [ "hel", "ohm", "um", "lo", "cham" ],
+    "stats": [
+        "5% Chance To Cast Level 18 Volcano On Striking",
+        "Level 12 Holy Freeze Aura When Equipped",
+        "+2 To All Skills",
+        "+45% Increased Attack Speed",
+        "+330-370% Enhanced Damage (varies)",
+        "-(40-60)% To Enemy Cold Resistance (varies)",
+        "20% Deadly Strike",
+        "25% Chance of Open Wounds",
+        "Prevent Monster Heal",
+        "Freezes Target +3",
+        "Requirements -20%"
+    ]
+  },
+  {
+    "name": "Duress",
+    "version": "1.10",
+    "type": "Armor",
+    "runes": [ "shael", "um", "thul" ],
+    "stats": [
+        "+40% Faster Hit Recovery",
+        "+10-20% Enhanced Damage (varies)",
+        "Adds 37-133 Cold Damage 2 sec. Duration (Normal)",
+        "15% Chance of Crushing Blow",
+        "33% Chance of Open Wounds",
+        "+150-200% Enhanced Defense (varies)",
+        "-20% Slower Stamina Drain",
+        "Cold Resist +45%",
+        "Lightning Resist +15%",
+        "Fire Resist +15%",
+        "Poison Resist +15%"
+    ]
+  },
+  {
+    "name": "Enigma",
+    "version": "1.10",
+    "type": "Armor",
+    "runes": [ "jah", "ith", "ber" ],
+    "stats": [
+        "+2 To All Skills",
+        "+45% Faster Run/Walk",
+        "+1 To Teleport",
+        "+750-775 Defense (varies)",
+        "+ (0.75 Per Character Level) +0-74 To Strength (Based On Character Level)",
+        "Increase Maximum Life 5%",
+        "Damage Reduced By 8%",
+        "+14 Life After Each Kill",
+        "15% Damage Taken Goes To Mana",
+        "+ (1 Per Character Level) +1-99% Better Chance of Getting Magic Items (Based On Character Level)"
+    ]
+  },
+  {
+    "name": "Eternity",
+    "version": "1.10",
+    "type": "Melee Weapons",
+    "runes": [ "amn", "ber", "ist", "sol", "sur" ],
+    "stats": [
+        "Indestructible",
+        "+260-310% Enhanced Damage (varies)",
+        "+9 To Minimum Damage",
+        "7% Life Stolen Per Hit",
+        "20% Chance of Crushing Blow",
+        "Hit Blinds Target",
+        "Slows Target By 33%",
+        "Regenerate Mana 16%",
+        "Replenish Life +16",
+        "Cannot Be Frozen",
+        "30% Better Chance Of Getting Magic Items",
+        "Level 8 Revive (88 Charges)"
+    ]
+  },
+  {
+    "name": "Exile",
+    "version": "1.10",
+    "type": "Paladin Shields",
+    "runes": [ "vex", "ohm", "ist", "dol" ],
+    "stats": [
+        "15% Chance To Cast Level 5 Life Tap On Striking",
+        "Level 13-16 Defiance Aura When Equipped (varies)",
+        "+2 To Offensive Auras (Paladin Only)",
+        "+30% Faster Block Rate",
+        "Freezes Target",
+        "+220-260% Enhanced Defense (varies)",
+        "Replenish Life +7",
+        "+5% To Maximum Cold Resist",
+        "+5% To Maximum Fire Resist",
+        "25% Better Chance Of Getting Magic Items",
+        "Repairs 1 Durability in 4 Seconds"
+    ]
+  },
+  {
+    "name": "Famine",
+    "version": "1.10",
+    "type": "Axes/Hammers",
+    "runes": [ "fal", "ohm", "ort", "jah" ],
+    "stats": [
+        "+30% Increased Attack Speed",
+        "+320-370% Enhanced Damage (varies)",
+        "Ignore Target's Defense",
+        "Adds 180-200 Magic Damage",
+        "Adds 50-200 Fire Damage",
+        "Adds 51-250 Lightning Damage",
+        "Adds 50-200 Cold Damage",
+        "12% Life Stolen Per Hit",
+        "Prevent Monster Heal",
+        "+10 To Strength"
+    ]
+  },
+  {
+    "name": "Gloom",
+    "version": "1.10",
+    "type": "Armor",
+    "runes": [ "fal", "um", "pul" ],
+    "stats": [
+        "15% Chance To Cast Level 3 Dim Vision When Struck",
+        "+10% Faster Hit Recovery",
+        "+200-260% Enhanced Defense (varies)",
+        "+10 To Strength",
+        "All Resistances +45",
+        "Half Freeze Duration",
+        "5% Damage Taken Goes To Mana",
+        "-3 To Light Radius"
+    ]
+  },
+  {
+    "name": "Hand of Justice",
+    "version": "1.10",
+    "type": "Weapons",
+    "runes": [ "sur", "cham", "amn", "lo" ],
+    "stats": [
+        "100% Chance To Cast Level 36 Blaze When You Level-Up",
+        "100% Chance To Cast Level 48 Meteor When You Die",
+        "Level 16 Holy Fire Aura When Equipped",
+        "+33% Increased Attack Speed",
+        "+280-330% Enhanced Damage (varies)",
+        "Ignore Target's Defense",
+        "7% Life Stolen Per Hit",
+        "-20% To Enemy Fire Resistance",
+        "20% Deadly Strike",
+        "Hit Blinds Target",
+        "Freezes Target +3"
+    ]
+  },
+  {
+    "name": "Heart of the Oak",
+    "version": "1.10",
+    "type": "Staves/Maces",
+    "runes": [ "ko", "vex", "pul", "thul" ],
+    "stats": [
+        "+3 To All Skills",
+        "+40% Faster Cast Rate",
+        "+75% Damage To Demons",
+        "+100 To Attack Rating Against Demons",
+        "Adds 3-14 Cold Damage, 3 sec. Duration (Normal)",
+        "7% Mana Stolen Per Hit",
+        "+10 To Dexterity",
+        "Replenish Life +20",
+        "Increase Maximum Mana 15%",
+        "All Resistances +30-40 (varies)",
+        "Level 4 Oak Sage (25 Charges)",
+        "Level 14 Raven (60 Charges)"
+    ]
+  },
+  {
+    "name": "Kingslayer",
+    "version": "1.10",
+    "type": "Swords/Axes",
+    "runes": [ "mal", "um", "gul", "fal" ],
+    "stats": [
+        "+30% Increased Attack Speed",
+        "+230-270% Enhanced Damage (varies)",
+        "-25% Target Defense",
+        "20% Bonus To Attack Rating",
+        "33% Chance of Crushing Blow",
+        "50% Chance of Open Wounds",
+        "+1 To Vengeance",
+        "Prevent Monster Heal",
+        "+10 To Strength",
+        "40% Extra Gold From Monsters"
+    ]
+  },
+  {
+    "name": "Passion",
+    "version": "1.10",
+    "type": "Weapons",
+    "runes": [ "dol", "ort", "eld", "lem" ],
+    "stats": [
+        "+25% Increased Attack Speed",
+        "+160-210% Enhanced Damage (varies)",
+        "50-80% Bonus To Attack Rating (varies)",
+        "+75% Damage To Undead",
+        "+50 To Attack Rating Against Undead",
+        "Adds 1-50 Lightning Damage",
+        "+1 To Berserk",
+        "+1 To Zeal",
+        "Hit Blinds Target +10",
+        "Hit Causes Monster To Flee 25%",
+        "75% Extra Gold From Monsters",
+        "Level 3 Heart of Wolverine (12 Charges)"
+    ]
+  },
+  {
+    "name": "Prudence",
+    "version": "1.10",
+    "type": "Armor",
+    "runes": [ "mal", "tir" ],
+    "stats": [
+        "+25% Faster Hit Recovery",
+        "+140-170% Enhanced Defense (varies)",
+        "All Resistances +25-35 (varies)",
+        "Damage Reduced by 3",
+        "Magic Damage Reduced by 17",
+        "+2 To Mana After Each Kill",
+        "+1 To Light Radius",
+        "Repairs Durability 1 In 4 Seconds"
+    ]
+  },
+  {
+    "name": "Sanctuary",
+    "version": "1.10",
+    "type": "Shields",
+    "runes": [ "ko", "ko", "mal" ],
+    "stats": [
+        "+20% Faster Hit Recovery",
+        "+20% Faster Block Rate",
+        "20% Increased Chance of Blocking",
+        "+130-160% Enhanced Defense (varies)",
+        "+250 Defense vs. Missile",
+        "+20 To Dexterity",
+        "All Resistances +50-70 (varies)",
+        "Magic Damage Reduced By 7",
+        "Level 12 Slow Missiles (60 Charges)"
+    ]
+  },
+  {
+    "name": "Splendor",
+    "version": "1.10",
+    "type": "Shields",
+    "runes": [ "eth", "lum" ],
+    "stats": [
+        "+1 To All Skills",
+        "+10% Faster Cast Rate",
+        "+20% Faster Block Rate",
+        "+60-100% Enhanced Defense (varies)",
+        "+10 To Energy",
+        "Regenerate Mana 15%",
+        "50% Extra Gold From Monsters",
+        "20% Better Chance of Getting Magic Items",
+        "+3 To Light Radius"
+    ]
+  },
+  {
+    "name": "Stone",
+    "version": "1.10",
+    "type": "Armor",
+    "runes": [ "shael", "um", "pul", "lum" ],
+    "stats": [
+        "+60% Faster Hit Recovery",
+        "+250-290% Enhanced Defense (varies)",
+        "+300 Defense Vs. Missile",
+        "+16 To Strength",
+        "+16 To Vitality",
+        "+10 To Energy",
+        "All Resistances +15",
+        "Level 16 Molten Boulder (80 Charges)",
+        "Level 16 Clay Golem (16 Charges)"
+    ]
+  },
+  {
+    "name": "Wind",
+    "version": "1.10",
+    "type": "Melee Weapons",
+    "runes": [ "sur", "el" ],
+    "stats": [
+        "10% Chance To Cast Level 9 Tornado On Striking",
+        "+20% Faster Run/Walk",
+        "+40% Increased Attack Speed",
+        "+15% Faster Hit Recovery",
+        "+120-160% Enhanced Damage (varies)",
+        "-50% Target Defense",
+        "+50 To Attack Rating",
+        "Hit Blinds Target",
+        "+1 To Light Radius",
+        "Level 13 Twister (127 Charges)"
+    ]
+  },
+  {
+    "name": "",
+    "version": "1.10 Ladder",
+    "type": "",
+    "runes": [  ],
+    "stats": [
+
     ]
   }
 ]


### PR DESCRIPTION
All non-ladder runewords for v1.10 have been added. Also removed the sockets and runename fields as both can be derived from the runes list and corrected some typos in the original runewords. One less point of failure!